### PR TITLE
Fix crash on exit

### DIFF
--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -43,10 +43,7 @@ struct shader_preset_file
   std::string path;
 };
 
-CShaderPreset::~CShaderPreset()
-{
-  CLog::Get().SetType(SYS_LOG_TYPE_CONSOLE);
-}
+CShaderPreset::~CShaderPreset() = default;
 
 // CAddonBase overrides
 

--- a/src/log/Log.cpp
+++ b/src/log/Log.cpp
@@ -49,10 +49,7 @@ CLog& CLog::Get(void)
   return _instance;
 }
 
-CLog::~CLog(void)
-{
-  SetPipe(NULL);
-}
+CLog::~CLog(void) = default;
 
 bool CLog::SetType(SYS_LOG_TYPE type)
 {


### PR DESCRIPTION
## Description

This PR introduces a crash-on-exit fit that appeared when rebasing shaders on 19 alpha 1. The add-on sets the pipe back to the console so that the add-on doesn't get called after it is destructed. However, because the add-on can't be run outside kodi, no logging will occur after destruction, so it's proper to remove this function call.

## How has this been tested?

Tested on my `retroplayer-19alpha1` branch on Windows 10.

Loaded Kodi, played a game with the awesome CRT shader, exited Kodi, observed no crash.