### PR TITLE
Update for Nexus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,16 @@ matrix:
       sudo: required
       compiler: gcc
       env: DEBIAN_BUILD=true
+    - os: linux
+      dist: focal
+      sudo: required
+      compiler: gcc
+      env: DEBIAN_BUILD=true
     - os: osx
       osx_image: xcode10.2
 
 before_install:
-  - if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/xbmc-nightly; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/ppa; fi
   - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get update; fi
   - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get install fakeroot; fi
 
@@ -40,7 +45,7 @@ before_install:
 #
 before_script:
   - if [[ $DEBIAN_BUILD != true ]]; then cd $TRAVIS_BUILD_DIR/..; fi
-  - if [[ $DEBIAN_BUILD != true ]]; then git clone --branch retroplayer-19.5 --depth=1 https://github.com/garbear/xbmc.git; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then git clone --branch retroplayer-20alpha2 --depth=1 https://github.com/garbear/xbmc.git; fi
   - if [[ $DEBIAN_BUILD != true ]]; then cd ${app_id} && mkdir build && cd build; fi
   - if [[ $DEBIAN_BUILD != true ]]; then mkdir -p definition/${app_id}; fi
   - if [[ $DEBIAN_BUILD != true ]]; then echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt; fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ environment:
 
 build_script:
   - cd ..
-  - git clone --branch retroplayer-19.5 --depth=1 https://github.com/garbear/xbmc.git
+  - git clone --branch retroplayer-20alpha2 --depth=1 https://github.com/garbear/xbmc.git
   - cd %app_id%
   - mkdir build
   - cd build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
 trigger:
   branches:
     include:
-    - Matrix
+    - Nexus
     - releases/*
   paths:
     include:
@@ -46,7 +46,7 @@ jobs:
 
     - script: |
         cd ..
-        git clone --branch retroplayer-19.5 --depth=1 https://github.com/garbear/xbmc.git kodi
+        git clone --branch retroplayer-20alpha2 --depth=1 https://github.com/garbear/xbmc.git kodi
         cd $(Build.SourcesDirectory)
         mkdir build
         cd build

--- a/game.shader.presets/addon.xml.in
+++ b/game.shader.presets/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon
   id="game.shader.presets"
-  version="19.0.1"
+  version="20.0.0"
   name="Shader Preset Support"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>
@@ -10,10 +10,10 @@
     library_@PLATFORM@="@LIBRARY_FILENAME@"
     extensions="cgp|glslp|hlslp"/>
   <extension point="xbmc.addon.metadata">
-    <summary lang="en">Shader Preset Support</summary>
-    <description lang="en">This library provides support for libretro "meta" shaders, or .cgp files.</description>
+    <summary lang="en_GB">Shader Preset Support</summary>
+    <description lang="en_GB">This library provides support for libretro "meta" shaders, or .cgp files.</description>
     <platform>@PLATFORM@</platform>
-    <license>GPL-2.0-or-later</license>
+    <license>GPL-3.0-or-later</license>
     <source>https://github.com/kodi-game/game.shader.presets</source>
     <assets>
       <icon>resources/icon.png</icon>

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -51,15 +51,10 @@ ADDON_STATUS CShaderPreset::Create()
 {
   CLog::Get().SetPipe(new CLogAddon());
 
-  return GetStatus();
-}
-
-ADDON_STATUS CShaderPreset::SetSetting(const std::string& settingName, const kodi::CSettingValue& settingValue)
-{
   return ADDON_STATUS_OK;
 }
 
-ADDON_STATUS CShaderPreset::GetStatus()
+ADDON_STATUS CShaderPreset::SetSetting(const std::string& settingName, const kodi::addon::CSettingValue& settingValue)
 {
   return ADDON_STATUS_OK;
 }

--- a/src/addon.h
+++ b/src/addon.h
@@ -25,7 +25,7 @@
 
 struct rarch_video_shader;
 
-class ATTRIBUTE_HIDDEN CShaderPreset
+class ATTR_DLL_LOCAL CShaderPreset
   : public kodi::addon::CAddonBase,
     public kodi::addon::CInstanceShaderPreset
 {
@@ -35,8 +35,7 @@ public:
 
   // CAddonBase overrides
   virtual ADDON_STATUS Create() override;
-  virtual ADDON_STATUS GetStatus() override;
-  virtual ADDON_STATUS SetSetting(const std::string& settingName, const kodi::CSettingValue& settingValue) override;
+  virtual ADDON_STATUS SetSetting(const std::string& settingName, const kodi::addon::CSettingValue& settingValue) override;
 
   // CInstanceShaderPreset overrides
   preset_file PresetFileNew(const char *path) override;

--- a/src/log/LogAddon.cpp
+++ b/src/log/LogAddon.cpp
@@ -31,7 +31,7 @@ CLogAddon::CLogAddon()
 
 void CLogAddon::Log(SYS_LOG_LEVEL level, const char* logline)
 {
-  AddonLog loglevel;
+  ADDON_LOG loglevel;
 
   switch (level)
   {


### PR DESCRIPTION
## Description

I ported Windows and OpenGL shaders to Nexus, and these were the modifications I made to the shader preset add-on to get shaders working.

Link to test builds:

* https://github.com/garbear/xbmc/releases/tag/retroplayer-20alpha2-20220718

## How has this been tested?

### CI

CI succeeds for regular windows x86 and x64, but not for UWP x86 or x64.

Link to CI run: https://github.com/kodi-game/game.shader.presets/runs/7379338383

### Out of game

Kodi starts without crashing. Add-on appears in the add-on manager.

### In-game

Most video filters work in-game on my system. The only ones that don't are the three NTSC filters.
