### PR TITLE
Fix PAL shader for GLSL version 1.30

### DIFF
--- a/libretro/glsl/pal/shaders/pal-singlepass.glsl
+++ b/libretro/glsl/pal/shaders/pal-singlepass.glsl
@@ -166,7 +166,7 @@ uniform COMPAT_PRECISION float PHASE_NOISE;
                             
 #define fetch(ofs,center,invx) COMPAT_TEXTURE(Source, vec2((ofs) * (invx) + center.x, center.y))
 
-#define FIRTAPS 20.
+#define FIRTAPS 20
 #if __VERSION__ < 130
 float FIR1 = -0.008030271;
 float FIR2 = 0.003107906;


### PR DESCRIPTION
This 1 character patch fixes the PAL shader for GLSL versions 1.30 and above. Because this shader works also in the DX version, I've included it in the default selection.