### PR TITLE
Add new shader presets to XML

### DIFF
--- a/game.shader.presets/resources/ShaderPresetsGLSLP_GLES.xml
+++ b/game.shader.presets/resources/ShaderPresetsGLSLP_GLES.xml
@@ -21,16 +21,6 @@
         <name>Advanced AA</name>
     </preset>
     <preset>
-        <path>glsl/xbr/xbr-lv2.glslp</path>
-        <folder>xBR</folder>
-        <name>xBR-lv2</name>
-    </preset>
-    <preset>
-        <path>glsl/xbr/xbr-lv2-noblend.glslp</path>
-        <folder>xBR</folder>
-        <name>xBR-lv2 (no blend)</name>
-    </preset>
-    <preset>
         <path>glsl/xbr/xbr-lv3.glslp</path>
         <folder>xBR</folder>
         <name>xBR-lv3</name>
@@ -49,11 +39,6 @@
         <path>glsl/xbrz/xbrz-freescale.glslp</path>
         <folder>xBRZ</folder>
         <name>xBRZ Freescale</name>
-    </preset>
-    <preset>
-        <path>glsl/crt/crt-hyllian.glslp</path>
-        <folder>CRT</folder>
-        <name>CRT Hyllian</name>
     </preset>
     <preset>
         <path>glsl/crt/crt-easymode.glslp</path>
@@ -86,14 +71,9 @@
         <name>CRT Consumer</name>
     </preset>
     <preset>
-        <path>glsl/crt/crt-lottes-alpha.glslp</path>
+        <path>glsl/crt/crt-lottes.glslp</path>
         <folder>CRT</folder>
         <name>CRT Lottes</name>
-    </preset>
-    <preset>
-        <path>glsl/pal/Amiga_a520.glslp</path>
-        <folder>PAL</folder>
-        <name>Amiga A520</name>
     </preset>
     <preset>
         <path>glsl/ntsc/ntsc-svideo.glslp</path>

--- a/game.shader.presets/resources/ShaderPresetsHLSLP.xml
+++ b/game.shader.presets/resources/ShaderPresetsHLSLP.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" ?>
 <presets>
     <preset>
-        <path>hlsl/anti-aliasing/advanced-aa.cgp</path>
-        <folder>Anti-Aliasing</folder>
-        <name>Advanced AA</name>
-    </preset>
-    <preset>
         <path>hlsl/scalenx/scale2x.cgp</path>
         <folder>Scale</folder>
         <name>Scale 2x</name>
@@ -19,6 +14,11 @@
         <path>hlsl/eagle/super-eagle.cgp</path>
         <folder>Eagle</folder>
         <name>Super Eagle</name>
+    </preset>
+    <preset>
+        <path>hlsl/anti-aliasing/advanced-aa.cgp</path>
+        <folder>Anti-Aliasing</folder>
+        <name>Advanced AA</name>
     </preset>
     <preset>
         <path>hlsl/xbr/xbr-lv2-fast.cgp</path>
@@ -41,24 +41,24 @@
         <name>4xBR Hybrid</name>
     </preset>
     <preset>
-        <path>hlsl/crt/crt-lottes.cgp</path>
-        <folder>CRT</folder>
-        <name>CRT Lottes</name>
-    </preset>
-    <preset>
         <path>hlsl/crt/crt-geom.cgp</path>
         <folder>CRT</folder>
         <name>CRT Geom</name>
     </preset>
     <preset>
-        <path>hlsl/ntsc/ntsc.cgp</path>
-        <folder>NTSC</folder>
-        <name>NTSC</name>
+        <path>hlsl/crt/crt-lottes.cgp</path>
+        <folder>CRT</folder>
+        <name>CRT Lottes</name>
     </preset>
     <preset>
         <path>hlsl/pal/pal-singlepass.cgp</path>
         <folder>PAL</folder>
         <name>PAL</name>
+    </preset>
+    <preset>
+        <path>hlsl/ntsc/ntsc.cgp</path>
+        <folder>NTSC</folder>
+        <name>NTSC</name>
     </preset>
     <preset>
         <path>hlsl/handheld/lcd3x.cgp</path>

--- a/libretro/glsl/crt/crt-lottes-alpha.glslp
+++ b/libretro/glsl/crt/crt-lottes-alpha.glslp
@@ -1,0 +1,7 @@
+shaders = 2
+
+shader0 = ../stock.glsl
+filter_linear0 = false
+
+shader1 = shaders/crt-lottes.glsl
+filter_linear1 = false


### PR DESCRIPTION
This PR adds new presets to the GLSL XML. All of the presets are tested to render correctly for all stretch modes after the https://github.com/xbmc/xbmc/pull/26961.

There is also added workaround for missing alpha channel in CRT Lottes (fixes borders) for OpenGL Core profile.

And I've also added a new XML for GLES with removed presets, which can't work in GLES.

The idea is, that GLES is mostly running on low performance devices and some of the more demanding shaders will definitely not work there (will be too slow). So we can have 3rd XML for GLES, which can be optimized for less powerful devices. There are some presets, which do have their "Lite" variants for low performance devices, so we can later use those instead.

Lets test the current GLES XML on the most powerful GLES device we know, the Shield. Please report those presets, that are not usable there, so I can optimize the GLES XML. We can do the optimization for GLES in another PR later, so we don't block this one.