### PR TITLE
Fix copy/paste bug

### DIFF
--- a/src/utils/RarchTranslator.cpp
+++ b/src/utils/RarchTranslator.cpp
@@ -234,7 +234,7 @@ void CRarchTranslator::TranslateShaderPass(const video_shader_pass &pass, rarch_
     rarch_fbo.scale_x = fbo.scale_x.scale;
     break;
   }
-  switch (fbo.scale_y.type)
+  switch (rarch_fbo.type_y)
   {
   case RARCH_SCALE_ABSOLUTE:
     rarch_fbo.abs_y = fbo.scale_y.abs;


### PR DESCRIPTION
## Description

Found a c/p error when updating libretro-common.

## How has this been tested?

Before, building on macOS ARM:

```
RarchTranslator.cpp:237:8: warning: comparison of different enumeration types in switch statement ('SHADER_SCALE_TYPE' and 'gfx_scale_type') [-Wenum-compare-switch]
  235 |   switch (fbo.scale_y.type)
      |           ~~~~~~~~~~~~~~~~
  236 |   {
  237 |   case RARCH_SCALE_ABSOLUTE:
      |        ^~~~~~~~~~~~~~~~~~~~
1 warning generated.
```

After: warning is gone.