### PR TITLE
[Shader Preset API v1.1.0] Add support for "alias" parameter

### DIFF
--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -157,6 +157,7 @@ void CShaderPreset::ShaderPresetFree(video_shader &shader)
     delete[] pass.source_path;
     delete[] pass.vertex_source;
     delete[] pass.fragment_source;
+    delete[] pass.alias;
   }
   delete[] shader.passes;
 

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -72,6 +72,8 @@ preset_file CShaderPreset::PresetFileNew(const char *path)
 void CShaderPreset::PresetFileFree(preset_file file)
 {
   shader_preset_file *preset_file = static_cast<shader_preset_file*>(file);
+  if (preset_file == nullptr)
+    return;
 
   config_file_free(preset_file->rarch_conf);
 
@@ -81,6 +83,8 @@ void CShaderPreset::PresetFileFree(preset_file file)
 bool CShaderPreset::ShaderPresetRead(preset_file file, video_shader &shader)
 {
   shader_preset_file *preset_file = static_cast<shader_preset_file*>(file);
+  if (preset_file == nullptr)
+    return false;
 
   rarch_video_shader rarch_shader;
 
@@ -108,22 +112,28 @@ bool CShaderPreset::ShaderPresetRead(preset_file file, video_shader &shader)
   return true;
 }
 
-void CShaderPreset::ShaderPresetWrite(preset_file file, const video_shader &shader)
+bool CShaderPreset::ShaderPresetWrite(preset_file file, const video_shader &shader)
 {
   shader_preset_file *preset_file = static_cast<shader_preset_file*>(file);
+  if (preset_file == nullptr)
+    return false;
 
   rarch_video_shader rarch_shader;
 
   CRarchTranslator::TranslateShader(shader, rarch_shader, preset_file->path);
 
-  video_shader_write_preset(preset_file->rarch_conf->path, &rarch_shader, false);
+  const bool success = video_shader_write_preset(preset_file->rarch_conf->path, &rarch_shader, false);
 
   CRarchTranslator::FreeShader(rarch_shader);
+
+  return success;
 }
 
 bool CShaderPreset::ShaderPresetResolveParameters(preset_file file, video_shader &shader)
 {
   shader_preset_file *preset_file = static_cast<shader_preset_file*>(file);
+  if (preset_file == nullptr)
+    return false;
 
   rarch_video_shader rarch_shader;
 

--- a/src/addon.h
+++ b/src/addon.h
@@ -41,7 +41,7 @@ public:
   preset_file PresetFileNew(const char *path) override;
   void PresetFileFree(preset_file file) override;
   bool ShaderPresetRead(preset_file file, video_shader &shader) override;
-  void ShaderPresetWrite(preset_file file, const video_shader &shader) override;
+  bool ShaderPresetWrite(preset_file file, const video_shader &shader) override;
   bool ShaderPresetResolveParameters(preset_file file, video_shader &shader) override;
   void ShaderPresetFree(video_shader &shader) override;
 };

--- a/src/utils/RarchTranslator.cpp
+++ b/src/utils/RarchTranslator.cpp
@@ -190,6 +190,14 @@ void CRarchTranslator::TranslateShaderPass(const rarch_video_shader_pass &rarch_
   pass.wrap = TranslateWrapType(rarch_pass.wrap);
   pass.frame_count_mod = rarch_pass.frame_count_mod;
   pass.mipmap = rarch_pass.mipmap;
+
+  pass.alias = nullptr;
+  const unsigned int alias_len = std::strlen(rarch_pass.alias);
+  if (alias_len > 0)
+  {
+    pass.alias = new char[alias_len + 1];
+    std::strncpy(pass.alias, rarch_pass.alias, alias_len + 1);
+  }
 }
 
 void CRarchTranslator::TranslateShaderPass(const video_shader_pass &pass, rarch_video_shader_pass &rarch_pass, const std::string &configPath)
@@ -215,6 +223,15 @@ void CRarchTranslator::TranslateShaderPass(const video_shader_pass &pass, rarch_
   }
 
   rarch_pass.alias[0] = '\0';
+  if (pass.alias != nullptr)
+  {
+    const unsigned int alias_len = std::strlen(pass.alias);
+    if (alias_len > 0)
+    {
+      std::strncpy(rarch_pass.alias, pass.alias, sizeof(rarch_pass.alias) - 1);
+      rarch_pass.alias[sizeof(rarch_pass.alias) - 1] = '\0'; // Ensure null-termination
+    }
+  }
 
   auto &rarch_fbo = rarch_pass.fbo;
   auto &fbo = pass.fbo;


### PR DESCRIPTION
## Description

As title says, this PR adds support for the `alias` parameter used by some shader presets such as CRT-Royale.

Requires https://github.com/xbmc/xbmc/pull/27061

## How has this been tested?

Tested as part of https://github.com/xbmc/xbmc/pull/27061.