### PR TITLE
Fix build error on Win32

### DIFF
--- a/src/depends/libretro-common/include/compat/msvc.h
+++ b/src/depends/libretro-common/include/compat/msvc.h
@@ -57,17 +57,6 @@ extern "C"  {
 #define _USE_MATH_DEFINES
 #include <math.h>
 
-/* Python headers defines ssize_t and sets HAVE_SSIZE_T.
- * Cannot duplicate these efforts.
- */
-#ifndef HAVE_SSIZE_T
-#if defined(_WIN64)
-typedef __int64 ssize_t;
-#elif defined(_WIN32)
-typedef int ssize_t;
-#endif
-#endif
-
 #define mkdir(dirname, unused) _mkdir(dirname)
 #define strtoull _strtoui64
 #undef strcasecmp

--- a/src/depends/libretro-common/include/retro_common_api.h
+++ b/src/depends/libretro-common/include/retro_common_api.h
@@ -58,23 +58,6 @@ special technique is called for.
 
 #endif
 
-/*
-IMO, this non-standard ssize_t should not be used.
-However, it's a good example of how to handle something like this.
-*/
-#ifdef _MSC_VER
-#ifndef HAVE_SSIZE_T
-#define HAVE_SSIZE_T
-#if defined(_WIN64)
-typedef __int64 ssize_t;
-#elif defined(_WIN32)
-typedef int ssize_t;
-#endif
-#endif
-#elif defined(__MACH__)
-#include <sys/types.h>
-#endif
-
 #ifdef _MSC_VER
 #if _MSC_VER >= 1800
 #include <inttypes.h>


### PR DESCRIPTION
## Description

Win32 started failing, probably after the add-on API bump. I haven't tested but removing this cruft should fix the build.

Error was:

```
src\depends\libretro-common\include\retro_common_api.h(71,13): error C2371: 'ssize_t': redefinition; different basic types
```