### PR TITLE
Add new Big Blur and Uborder presets

### DIFF
--- a/game.shader.presets/resources/ShaderPresetsGLSLP.xml
+++ b/game.shader.presets/resources/ShaderPresetsGLSLP.xml
@@ -51,11 +51,6 @@
         <name>xBRZ Freescale</name>
     </preset>
     <preset>
-        <path>glsl/crt/crt-hyllian.glslp</path>
-        <folder>CRT</folder>
-        <name>CRT Hyllian</name>
-    </preset>
-    <preset>
         <path>glsl/crt/crt-easymode.glslp</path>
         <folder>CRT</folder>
         <name>CRT EasyMode</name>
@@ -64,6 +59,11 @@
         <path>glsl/crt/crt-easymode-halation.glslp</path>
         <folder>CRT</folder>
         <name>CRT EasyMode Halation</name>
+    </preset>
+    <preset>
+        <path>glsl/crt/crt-hyllian.glslp</path>
+        <folder>CRT</folder>
+        <name>CRT Hyllian</name>
     </preset>
     <preset>
         <path>glsl/crt/crtglow_lanczos.glslp</path>
@@ -81,14 +81,14 @@
         <name>CRT Geom</name>
     </preset>
     <preset>
-        <path>glsl/crt/crt-consumer.glslp</path>
-        <folder>CRT</folder>
-        <name>CRT Consumer</name>
-    </preset>
-    <preset>
         <path>glsl/crt/crt-lottes-alpha.glslp</path>
         <folder>CRT</folder>
         <name>CRT Lottes</name>
+    </preset>
+    <preset>
+        <path>glsl/crt/crt-consumer.glslp</path>
+        <folder>CRT</folder>
+        <name>CRT Consumer</name>
     </preset>
     <preset>
         <path>glsl/pal/Amiga_a520.glslp</path>
@@ -121,6 +121,26 @@
         <name>PSP Color</name>
     </preset>
     <preset>
+        <path>glsl/handheld/console-border/gg-4x.glslp</path>
+        <folder>Console</folder>
+        <name>Game Gear 4x</name>
+    </preset>
+    <preset>
+        <path>glsl/handheld/console-border/gbc-4x.glslp</path>
+        <folder>Console</folder>
+        <name>Game Boy Color 4x</name>
+    </preset>
+    <preset>
+        <path>glsl/handheld/console-border/psp-2x.glslp</path>
+        <folder>Console</folder>
+        <name>PlayStation Portable 2x</name>
+    </preset>
+    <preset>
+        <path>glsl/bezel/uborder/base_presets/uborder-bezel-reflections/uborder-bezel-reflections-crt-nobody.glslp</path>
+        <folder>Bezel</folder>
+        <name>Uborder</name>
+    </preset>
+    <preset>
         <path>glsl/borders/bigblur.glslp</path>
         <folder>Borders</folder>
         <name>Big blur</name>
@@ -141,13 +161,13 @@
         <name>Snow</name>
     </preset>
     <preset>
-        <path>glsl/handheld/console-border/gbc-4x.glslp</path>
-        <folder>Console</folder>
-        <name>GBC 4x</name>
+        <path>glsl/presets/super-eagle+bigblur.glslp</path>
+        <folder>Presets</folder>
+        <name>Super Eagle + Big blur</name>
     </preset>
     <preset>
-        <path>glsl/handheld/console-border/psp-2x.glslp</path>
-        <folder>Console</folder>
-        <name>PSP 2x</name>
+        <path>glsl/presets/advanced-aa+bigblur.glslp</path>
+        <folder>Presets</folder>
+        <name>Advanced AA + Big blur</name>
     </preset>
 </presets>

--- a/game.shader.presets/resources/ShaderPresetsGLSLP_GLES.xml
+++ b/game.shader.presets/resources/ShaderPresetsGLSLP_GLES.xml
@@ -116,11 +116,6 @@
         <name>PlayStation Portable 2x</name>
     </preset>
     <preset>
-        <path>glsl/bezel/uborder/base_presets/uborder-bezel-reflections/uborder-bezel-reflections-crt-nobody.glslp</path>
-        <folder>Bezel</folder>
-        <name>Uborder</name>
-    </preset>
-    <preset>
         <path>glsl/borders/bigblur.glslp</path>
         <folder>Borders</folder>
         <name>Big blur</name>

--- a/game.shader.presets/resources/ShaderPresetsGLSLP_GLES.xml
+++ b/game.shader.presets/resources/ShaderPresetsGLSLP_GLES.xml
@@ -66,14 +66,14 @@
         <name>CRT Geom</name>
     </preset>
     <preset>
-        <path>glsl/crt/crt-consumer.glslp</path>
-        <folder>CRT</folder>
-        <name>CRT Consumer</name>
-    </preset>
-    <preset>
         <path>glsl/crt/crt-lottes.glslp</path>
         <folder>CRT</folder>
         <name>CRT Lottes</name>
+    </preset>
+    <preset>
+        <path>glsl/crt/crt-consumer.glslp</path>
+        <folder>CRT</folder>
+        <name>CRT Consumer</name>
     </preset>
     <preset>
         <path>glsl/ntsc/ntsc-svideo.glslp</path>
@@ -101,6 +101,26 @@
         <name>PSP Color</name>
     </preset>
     <preset>
+        <path>glsl/handheld/console-border/gg-4x.glslp</path>
+        <folder>Console</folder>
+        <name>Game Gear 4x</name>
+    </preset>
+    <preset>
+        <path>glsl/handheld/console-border/gbc-4x.glslp</path>
+        <folder>Console</folder>
+        <name>Game Boy Color 4x</name>
+    </preset>
+    <preset>
+        <path>glsl/handheld/console-border/psp-2x.glslp</path>
+        <folder>Console</folder>
+        <name>PlayStation Portable 2x</name>
+    </preset>
+    <preset>
+        <path>glsl/bezel/uborder/base_presets/uborder-bezel-reflections/uborder-bezel-reflections-crt-nobody.glslp</path>
+        <folder>Bezel</folder>
+        <name>Uborder</name>
+    </preset>
+    <preset>
         <path>glsl/borders/bigblur.glslp</path>
         <folder>Borders</folder>
         <name>Big blur</name>
@@ -121,13 +141,13 @@
         <name>Snow</name>
     </preset>
     <preset>
-        <path>glsl/handheld/console-border/gbc-4x.glslp</path>
-        <folder>Console</folder>
-        <name>GBC 4x</name>
+        <path>glsl/presets/super-eagle+bigblur.glslp</path>
+        <folder>Presets</folder>
+        <name>Super Eagle + Big blur</name>
     </preset>
     <preset>
-        <path>glsl/handheld/console-border/psp-2x.glslp</path>
-        <folder>Console</folder>
-        <name>PSP 2x</name>
+        <path>glsl/presets/advanced-aa+bigblur.glslp</path>
+        <folder>Presets</folder>
+        <name>Advanced AA + Big blur</name>
     </preset>
 </presets>

--- a/libretro/glsl/bezel/uborder/shaders/content_bezel_shaders/crt-nobody-bezel-reflections.glsl
+++ b/libretro/glsl/bezel/uborder/shaders/content_bezel_shaders/crt-nobody-bezel-reflections.glsl
@@ -29,7 +29,7 @@
    THE SOFTWARE.
 */
 
-#version 120
+#version 150
 
 #pragma parameter all_nonono           "ALL:"                             0.0    0.0   1.0 1.0
 #pragma parameter all_zoom             "    Zoom %"                     100.0   20.0 200.0 1.0
@@ -359,6 +359,7 @@ void main()
 #elif defined(FRAGMENT)
 
 #if __VERSION__ >= 130
+#undef COMPAT_VARYING
 #define COMPAT_VARYING in
 #define COMPAT_TEXTURE texture
 out vec4 FragColor;

--- a/libretro/glsl/borders/bigblur.glslp
+++ b/libretro/glsl/borders/bigblur.glslp
@@ -2,6 +2,7 @@ shaders = 9
 
 shader0 = ../stock.glsl
 alias0 = Reference
+filter_linear0 = false
 
 shader1 = ../blurs/shaders/kawase/linearize.glsl
 srgb_framebuffer1 = true

--- a/libretro/glsl/borders/resources/bigblur.glsl
+++ b/libretro/glsl/borders/resources/bigblur.glsl
@@ -133,7 +133,7 @@ uniform COMPAT_PRECISION vec2 OutputSize;
 uniform COMPAT_PRECISION vec2 TextureSize;
 uniform COMPAT_PRECISION vec2 InputSize;
 uniform sampler2D Texture;
-uniform sampler2D OrigTexture;
+uniform sampler2D ReferenceTexture;
 COMPAT_VARYING vec4 TEX0;
 COMPAT_VARYING vec2 tex_border;
 
@@ -204,6 +204,6 @@ vec4 border(vec2 texture_size, vec2 video_size, vec2 output_size,
 void main()
 {
     FragColor = border(TextureSize, InputSize, OutputSize,
-		float(FrameCount), vTexCoord, Source, tex_border, OrigTexture);
+		float(FrameCount), vTexCoord, Source, tex_border, ReferenceTexture);
 } 
 #endif

--- a/libretro/glsl/presets/advanced-aa+bigblur.glslp
+++ b/libretro/glsl/presets/advanced-aa+bigblur.glslp
@@ -1,0 +1,52 @@
+shaders = 10
+
+shader0 = ../anti-aliasing/shaders/advanced-aa.glsl
+alias0 = Reference
+filter_linear0 = false
+scale_type0 = source
+scale_x0 = 2.0
+scale_y0 = 2.0
+
+shader1 = ../stock.glsl
+filter_linear1 = true
+scale_type1 = source
+scale_x1 = 0.5
+scale_y1 = 0.5
+
+shader2 = ../blurs/shaders/kawase/linearize.glsl
+srgb_framebuffer2 = true
+scale_type2 = source
+
+shader3 = ../blurs/shaders/kawase/kawase0.glsl
+filter_linear3 = true
+srgb_framebuffer3 = true
+scale_type3 = source
+
+shader4 = ../blurs/shaders/kawase/kawase1.glsl
+filter_linear4 = true
+srgb_framebuffer4 = true
+scale_type4 = source
+
+shader5 = ../blurs/shaders/kawase/kawase1.glsl
+filter_linear5 = true
+srgb_framebuffer5 = true
+scale_type5 = source
+
+shader6 = ../blurs/shaders/kawase/kawase2.glsl
+filter_linear6 = true
+srgb_framebuffer6 = true
+scale_type6 = source
+
+shader7 = ../blurs/shaders/kawase/kawase3.glsl
+filter_linear7 = true
+srgb_framebuffer7 = true
+scale_type7 = source
+
+shader8 = ../blurs/shaders/kawase/delinearize.glsl
+filter_linear8 = true
+
+shader9 = ../borders/resources/bigblur.glsl
+filter_linear9 = true
+
+parameters = "integer_scale"
+integer_scale = "0.000000"

--- a/libretro/glsl/presets/super-eagle+bigblur.glslp
+++ b/libretro/glsl/presets/super-eagle+bigblur.glslp
@@ -1,0 +1,52 @@
+shaders = 10
+
+shader0 = ../eagle/shaders/supereagle.glsl
+alias0 = Reference
+filter_linear0 = false
+scale_type0 = source
+scale_x0 = 2.0
+scale_y0 = 2.0
+
+shader1 = ../stock.glsl
+filter_linear1 = true
+scale_type1 = source
+scale_x1 = 0.5
+scale_y1 = 0.5
+
+shader2 = ../blurs/shaders/kawase/linearize.glsl
+srgb_framebuffer2 = true
+scale_type2 = source
+
+shader3 = ../blurs/shaders/kawase/kawase0.glsl
+filter_linear3 = true
+srgb_framebuffer3 = true
+scale_type3 = source
+
+shader4 = ../blurs/shaders/kawase/kawase1.glsl
+filter_linear4 = true
+srgb_framebuffer4 = true
+scale_type4 = source
+
+shader5 = ../blurs/shaders/kawase/kawase1.glsl
+filter_linear5 = true
+srgb_framebuffer5 = true
+scale_type5 = source
+
+shader6 = ../blurs/shaders/kawase/kawase2.glsl
+filter_linear6 = true
+srgb_framebuffer6 = true
+scale_type6 = source
+
+shader7 = ../blurs/shaders/kawase/kawase3.glsl
+filter_linear7 = true
+srgb_framebuffer7 = true
+scale_type7 = source
+
+shader8 = ../blurs/shaders/kawase/delinearize.glsl
+filter_linear8 = true
+
+shader9 = ../borders/resources/bigblur.glsl
+filter_linear9 = true
+
+parameters = "integer_scale"
+integer_scale = "0.000000"


### PR DESCRIPTION
This item was on my _TODO_ list for a long time. I liked the idea of the _Big Blur_ border shader, but it is not very practical on its own. I've already tried to create a combined preset with simple upscaling shader + the _Big Blur_ borders last year, but previously it was not possible to do it without heavy modifications to the shader code itself. Fortunately, it is now possible to do it pretty easily thanks to the shader pass alias support introduced earlier in https://github.com/xbmc/xbmc/pull/27768.

I've created 2 new persets, which combine common upscaling shaders with the _Big Blur_. They are ready to use out-of-box and they can also serve as an example, how we can combine presets. They depend on the parameter loading fix, which was merged yesterday, and also depend on the pass alias support. At least we now have some presets, which actually use the alias support and confirm, that it is working correctly.

I've also added 2 more cool presets, which I discovered along the way (_Game Gear_ and the _Uborder_ with the CRT TV and reflections).

<img width="1920" height="1080" alt="super-eagle+bigblur" src="https://github.com/user-attachments/assets/1eaa2ca6-d090-4f5d-8454-a491a1f7b817" />
<img width="1920" height="1080" alt="uborder" src="https://github.com/user-attachments/assets/a997eeb3-4c80-4954-acf2-6493b22b254f" />
