### PR TITLE
Fix uninitialized xBR-lv2 filter value

### DIFF
--- a/game.shader.presets/resources/ShaderPresetsGLSLP_GLES.xml
+++ b/game.shader.presets/resources/ShaderPresetsGLSLP_GLES.xml
@@ -21,6 +21,16 @@
         <name>Advanced AA</name>
     </preset>
     <preset>
+        <path>glsl/xbr/xbr-lv2.glslp</path>
+        <folder>xBR</folder>
+        <name>xBR-lv2</name>
+    </preset>
+    <preset>
+        <path>glsl/xbr/xbr-lv2-noblend.glslp</path>
+        <folder>xBR</folder>
+        <name>xBR-lv2 (no blend)</name>
+    </preset>
+    <preset>
         <path>glsl/xbr/xbr-lv3.glslp</path>
         <folder>xBR</folder>
         <name>xBR-lv3</name>

--- a/libretro/glsl/xbr/shaders/xbr-lv2.glsl
+++ b/libretro/glsl/xbr/shaders/xbr-lv2.glsl
@@ -288,6 +288,7 @@ void main()
 		i5 = mul( mat4x3(I5, C4, A1, G0), y_weight * Y );
 		h5 = mul( mat4x3(H5, F4, B1, D0), y_weight * Y );
 	}
+	f4 = h5.yzwx;
 
     // These inequations define the line below which interpolation occurs.
     fx   = (Ao*fp.y+Bo*fp.x); 


### PR DESCRIPTION
## Description

This PR fixes the remaining shaders on my macbook.

AI use:

The small-details refactor assigns i4, i5, and h5 in both branches but leaves f4 undefined before the corner and weighted-distance calculations read it.

Initialize f4 from the branch-selected h5 value, matching xBR-lv2-noblend, xBR-lv3, and the reference HLSL implementation. The expression is valid across the desktop GLSL and GLES compatibility paths.