### PR TITLE
Fix FXAA HLSL technique wrapper

### DIFF
--- a/libretro/hlsl/anti-aliasing/shaders/fx-aa.cg
+++ b/libretro/hlsl/anti-aliasing/shaders/fx-aa.cg
@@ -81,3 +81,5 @@ float4 main_fragment(COMPAT_IN_FRAGMENT) : COMPAT_Output
 {
 	return fxaa(COMPAT_texture_size, COMPAT_video_size, COMPAT_output_size, decal, VOUT.texCoord, VOUT.vpos);
 }
+
+COMPAT_END


### PR DESCRIPTION
## Description

AI use:

Fix the FXAA HLSL compatibility wrapper by emitting the missing `COMPAT_END`.

## Motivation and context

Without `COMPAT_END`, the shader does not emit the FX11 `TEQ` technique and `P0` pass expected by Kodi's DirectX renderer.

## How has this been tested?

Tested on Windows with Kodi's DirectX RetroPlayer renderer. FXAA compiles and renders successfully after the fix.

## What is the effect on users?

Fixes the FXAA video filter on Windows.