### PR TITLE
Promote failing GLSL shaders to 150

### DIFF
--- a/libretro/glsl/crt/shaders/crt-consumer/crt-consumer.glsl
+++ b/libretro/glsl/crt/shaders/crt-consumer/crt-consumer.glsl
@@ -1,4 +1,4 @@
-#version 110
+#version 150
 
 /* 
 crt-consumer by DariusG 2022-2024

--- a/libretro/glsl/crt/shaders/crt-consumer/glow_x.glsl
+++ b/libretro/glsl/crt/shaders/crt-consumer/glow_x.glsl
@@ -1,4 +1,4 @@
-#version 110
+#version 150
 
 #define pi 3.1415926535897932384626433
 

--- a/libretro/glsl/crt/shaders/crt-consumer/glow_y.glsl
+++ b/libretro/glsl/crt/shaders/crt-consumer/glow_y.glsl
@@ -1,4 +1,4 @@
-#version 110
+#version 150
 
 #define pi 3.1415926535897932384626433
 

--- a/libretro/glsl/crt/shaders/crt-consumer/linearize.glsl
+++ b/libretro/glsl/crt/shaders/crt-consumer/linearize.glsl
@@ -1,4 +1,4 @@
-#version 110
+#version 150
 
 #pragma parameter g_in "Gamma In" 2.4 1.0 4.0 0.05
 

--- a/libretro/glsl/crt/shaders/hyllian/crt-hyllian.glsl
+++ b/libretro/glsl/crt/shaders/hyllian/crt-hyllian.glsl
@@ -23,7 +23,7 @@
 
 */
 
-#version 120
+#version 150
 
 #pragma parameter BEAM_PROFILE "BEAM PROFILE (BP)" 0.0 0.0 6.0 1.0
 #pragma parameter BEAM_MIN_WIDTH "  Custom [If   BP=0.00] MIN BEAM WIDTH" 0.86 0.0 1.0 0.02

--- a/libretro/glsl/crt/shaders/zfast_crt_composite.glsl
+++ b/libretro/glsl/crt/shaders/zfast_crt_composite.glsl
@@ -1,4 +1,4 @@
-#version 110
+#version 150
 
 /*
     zfast_crt_composite, A very simple CRT shader

--- a/libretro/glsl/crt/shaders/zfast_crt_geo_svideo.glsl
+++ b/libretro/glsl/crt/shaders/zfast_crt_geo_svideo.glsl
@@ -1,4 +1,4 @@
-#version 110
+#version 150
 
 /*
     zfast_crt_geo_svideo - A simple, fast CRT shader.

--- a/libretro/glsl/misc/shaders/convergence.glsl
+++ b/libretro/glsl/misc/shaders/convergence.glsl
@@ -1,4 +1,4 @@
-#version 110
+#version 150
 
 /*
 convergence pass DariusG 2023. 

--- a/libretro/glsl/ntsc/shaders/ntsc-pass1-svideo-3phase.glsl
+++ b/libretro/glsl/ntsc/shaders/ntsc-pass1-svideo-3phase.glsl
@@ -1,4 +1,4 @@
-#version 130
+#version 150
 
 #define THREE_PHASE
 #define SVIDEO

--- a/libretro/glsl/ntsc/shaders/ntsc-pass2-3phase.glsl
+++ b/libretro/glsl/ntsc/shaders/ntsc-pass2-3phase.glsl
@@ -1,4 +1,4 @@
-#version 130
+#version 150
 
 #define fetch_offset(offset, one_x) \
    COMPAT_TEXTURE(Source, vTexCoord + vec2((offset) * (one_x), 0.0)).xyz

--- a/libretro/glsl/pal/shaders/a520.glsl
+++ b/libretro/glsl/pal/shaders/a520.glsl
@@ -1,4 +1,4 @@
-#version 130
+#version 150
 
 /*
     A modification of Retroarch PAL Shader 

--- a/libretro/glsl/xbr/shaders/xbr-lv2-noblend.glsl
+++ b/libretro/glsl/xbr/shaders/xbr-lv2-noblend.glsl
@@ -1,4 +1,4 @@
-#version 130
+#version 150
 
 /*
    Hyllian's xBR-lv2-noblend Shader

--- a/libretro/glsl/xbr/shaders/xbr-lv2.glsl
+++ b/libretro/glsl/xbr/shaders/xbr-lv2.glsl
@@ -1,4 +1,4 @@
-#version 130
+#version 150
 
 /*
    Hyllian's xBR-lv2 Shader

--- a/libretro/glsl/xbr/shaders/xbr-lv3.glsl
+++ b/libretro/glsl/xbr/shaders/xbr-lv3.glsl
@@ -1,4 +1,4 @@
-#version 130
+#version 150
 
 /*
    Hyllian's xBR-lv3 Shader

--- a/libretro/glsl/xbr/shaders/xbr-mlv4-multipass/xbr-mlv4-pass1.glsl
+++ b/libretro/glsl/xbr/shaders/xbr-mlv4-multipass/xbr-mlv4-pass1.glsl
@@ -1,4 +1,4 @@
-#version 130
+#version 150
 
 /*
 

--- a/libretro/glsl/xbr/shaders/xbr-mlv4-multipass/xbr-mlv4-pass2.glsl
+++ b/libretro/glsl/xbr/shaders/xbr-mlv4-multipass/xbr-mlv4-pass2.glsl
@@ -1,4 +1,4 @@
-#version 130
+#version 150
 
 /*
 

--- a/libretro/glsl/xbr/shaders/xbr-mlv4-multipass/xbr-mlv4-pass3.glsl
+++ b/libretro/glsl/xbr/shaders/xbr-mlv4-multipass/xbr-mlv4-pass3.glsl
@@ -1,4 +1,4 @@
-#version 130
+#version 150
 
 /*
 

--- a/libretro/glsl/xbr/shaders/xbr-mlv4-multipass/xbr-mlv4-pass4.glsl
+++ b/libretro/glsl/xbr/shaders/xbr-mlv4-multipass/xbr-mlv4-pass4.glsl
@@ -1,4 +1,4 @@
-#version 130
+#version 150
 
 /*
 


### PR DESCRIPTION
## Description

Promote the legacy shader sources used by nine curated presets from GLSL 110, 120, and 130 to GLSL 150. This works because existing compatibility macros select the modern core-profile syntax without further shader changes.

Update later passes exposed in xBR-mlv4, CRT Consumer, Amiga A520, and NTSC.

## How has this been tested?

Runtime-qualified all 34 curated GLSL presets on macOS.

Testing on Shield is next.