### PR TITLE
Fix xBR-lv2 shaders for GLES

### DIFF
--- a/libretro/glsl/xbr/shaders/xbr-lv2-noblend.glsl
+++ b/libretro/glsl/xbr/shaders/xbr-lv2-noblend.glsl
@@ -110,16 +110,6 @@ void main()
 
 #elif defined(FRAGMENT)
 
-#if __VERSION__ >= 130
-#define IN in
-#define tex2D texture
-out vec4 FragColor;
-#else
-#define IN varying
-#define FragColor gl_FragColor
-#define tex2D texture2D
-#endif
-
 #ifdef GL_ES
 #ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
@@ -129,6 +119,16 @@ precision mediump float;
 #define PRECISION mediump
 #else
 #define PRECISION
+#endif
+
+#if __VERSION__ >= 130
+#define IN in
+#define tex2D texture
+out vec4 FragColor;
+#else
+#define IN varying
+#define FragColor gl_FragColor
+#define tex2D texture2D
 #endif
 
 uniform PRECISION int FrameDirection;

--- a/libretro/glsl/xbr/shaders/xbr-lv2.glsl
+++ b/libretro/glsl/xbr/shaders/xbr-lv2.glsl
@@ -120,16 +120,6 @@ void main()
 
 #elif defined(FRAGMENT)
 
-#if __VERSION__ >= 130
-#define IN in
-#define tex2D texture
-out vec4 FragColor;
-#else
-#define IN varying
-#define FragColor gl_FragColor
-#define tex2D texture2D
-#endif
-
 #ifdef GL_ES
 #ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
@@ -139,6 +129,16 @@ precision mediump float;
 #define PRECISION mediump
 #else
 #define PRECISION
+#endif
+
+#if __VERSION__ >= 130
+#define IN in
+#define tex2D texture
+out vec4 FragColor;
+#else
+#define IN varying
+#define FragColor gl_FragColor
+#define tex2D texture2D
 #endif
 
 uniform PRECISION int FrameDirection;
@@ -175,9 +175,9 @@ const float coef         = 2.0;
 const vec3 rgbw          = vec3(14.352, 28.176, 5.472);
 const vec4 eq_threshold  = vec4(15.0, 15.0, 15.0, 15.0);
 
-vec4 delta   = vec4(1.0/XBR_SCALE, 1.0/XBR_SCALE, 1.0/XBR_SCALE, 1.0/XBR_SCALE);
-vec4 delta_l = vec4(0.5/XBR_SCALE, 1.0/XBR_SCALE, 0.5/XBR_SCALE, 1.0/XBR_SCALE);
-vec4 delta_u = delta_l.yxwz;
+const vec4 delta   = vec4(1.0/XBR_SCALE, 1.0/XBR_SCALE, 1.0/XBR_SCALE, 1.0/XBR_SCALE);
+const vec4 delta_l = vec4(0.5/XBR_SCALE, 1.0/XBR_SCALE, 0.5/XBR_SCALE, 1.0/XBR_SCALE);
+const vec4 delta_u = delta_l.yxwz;
 
 const  vec4 Ao = vec4( 1.0, -1.0, -1.0, 1.0 );
 const  vec4 Bo = vec4( 1.0,  1.0, -1.0,-1.0 );


### PR DESCRIPTION
## Description

Fix GLES compilation of the xBR-lv2 and xBR-lv2 (no blend) shaders.

* Move the GLES fragment precision declaration before `FragColor`.
* Make the xBR-lv2 delta vectors constant so their global initializer is valid in ESSL 300.

## Motivation and context

On NVIDIA Shield, both shaders failed to compile under GLES with missing fragment precision errors. xBR-lv2 also failed because a global initializer referenced a non-constant value.

## How has this been tested?

Before:

```text
xbr-lv2.glsl:
error C7573: OpenGL/ES requires precision specifier on this float type

xbr-lv2.glsl:
error C1059: non constant expression in initialization

xbr-lv2-noblend.glsl:
error C7573: OpenGL/ES requires precision specifier on this float type
```

After:

* Verified vertex and fragment compilation and linking with ANGLE using Kodi-equivalent ESSL 300 preprocessing.
* Runtime-tested all **34/34** curated GLSL presets on macOS Kodi with zero shader compile, link, creation, or OpenGL errors.
* Verified successfully on NVIDIA Shield.

## What is the effect on users?

Fixes xBR-lv2 and xBR-lv2 (no blend) on GLES devices.
